### PR TITLE
set fb marketing api version to 9.0 and add informative text

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -39,7 +39,7 @@ ___TEMPLATE_PARAMETERS___
     "name": "appId",
     "displayName": "Facebook App ID",
     "simpleValueType": true,
-    "help": "[optional] Add your Facebook App ID. Note! You have to configure the Customer Chat Plugin per \u003ca href\u003d\"https://developers.facebook.com/docs/messenger-platform/discovery/customer-chat-plugin\"\u003ethe instructions\u003c/a\u003e. This template is only used to load the Facebook Javascript SDK and add event listeners to the plugin and dialog load/show/hide events."
+    "help": "[optional] Add your Facebook App ID. Note! You have to configure the Customer Chat Plugin per \u003ca href\u003d\"https://developers.facebook.com/docs/messenger-platform/discovery/customer-chat-plugin\"\u003ethe instructions\u003c/a\u003e. This template is only used to load the Facebook Customer Chat SDK and add event listeners to the plugin and dialog load/show/hide events."
   },
   {
     "type": "GROUP",

--- a/template.tpl
+++ b/template.tpl
@@ -39,7 +39,7 @@ ___TEMPLATE_PARAMETERS___
     "name": "appId",
     "displayName": "Facebook App ID",
     "simpleValueType": true,
-    "help": "Add your Facebook App ID. Note! You have to configure the Customer Chat Plugin per \u003ca href\u003d\"https://developers.facebook.com/docs/messenger-platform/discovery/customer-chat-plugin\"\u003ethe instructions\u003c/a\u003e. This template is only used to add event listeners to the plugin and dialog load/show/hide events."
+    "help": "[optional] Add your Facebook App ID. Note! You have to configure the Customer Chat Plugin per \u003ca href\u003d\"https://developers.facebook.com/docs/messenger-platform/discovery/customer-chat-plugin\"\u003ethe instructions\u003c/a\u003e. This template is only used to load the Facebook Javascript SDK and add event listeners to the plugin and dialog load/show/hide events."
   },
   {
     "type": "GROUP",
@@ -127,7 +127,7 @@ const loaded = () => {
       appId            : data.appId,
       autoLogAppEvents : true,
       xfbml            : true,
-      version          : 'v6.0'
+      version          : 'v9.0'
     });
     if (data.pluginLoad) FB.Event.subscribe('customerchat.load', () => { cb('pluginLoad'); });
     if (data.pluginShow) FB.Event.subscribe('customerchat.show', () => { cb('pluginShow'); });


### PR DESCRIPTION
Made these changes recently to my own sites, so thought I'd initiate a PR if that would be helpful in any way. I don't have the expertise to look into any potential pitfalls the changes might generate, however the chat plugin works nicely with the changes made. 

Regarding the App ID section - I noticed that the app id is no longer required by FB (I run the chat without creating a developer app on FB), but rather provides additional features if implemented and linked up, hence I revised the information text next to the App ID field to include the word "[optional]". 

Thanks again for your awesome work provided to the community!